### PR TITLE
Update ContentTypeIconOptions's DefaultCachePath and DefaultCustomFontPath to use unix paths

### DIFF
--- a/src/Geta.Optimizely.ContentTypeIcons/Infrastructure/Configuration/ContentTypeIconOptions.cs
+++ b/src/Geta.Optimizely.ContentTypeIcons/Infrastructure/Configuration/ContentTypeIconOptions.cs
@@ -5,10 +5,10 @@
         public const int DefaultWidth = 120;
         public const int DefaultHeight = 90;
 
-        public const string DefaultCustomFontPath = "[appDataPath]\\fonts\\";
+        public const string DefaultCustomFontPath = "[appDataPath]/fonts/";
         public string CustomFontPath { get; set; } = DefaultCustomFontPath;
 
-        public const string DefaultCachePath = "[appDataPath]\\thumb_cache\\";
+        public const string DefaultCachePath = "[appDataPath]/thumb_cache/";
         public string CachePath { get; set; } = DefaultCachePath;
 
         public const string DefaultBackgroundColor = "#02423F";


### PR DESCRIPTION
Paths with backslashes don't work on macOS. Unix path style works on both Mac and Windows.
Another solution to this would be to ditch the constant strings in favor of Path.Combine.
e.g.: `public string CachePath { get; set; } = System.IO.Path.Combine("[appDataPath]", "thumb_cache")`

Here's how it behaves in macOS today
![image](https://user-images.githubusercontent.com/17810399/187916614-ecfebbe7-bb24-4e03-9cd7-db9d9fa8cab5.png)
Each file gets its filename prepended with "thumb_cache\" and the cache folder is named "thumb_cache\" with the trailing backslash. (Light blue items are folders and grey items are files)

Once the cache folder and any cached files are created you cannot execute `dotnet run` untill the files are removed.
The compiler fails with the following error message:
`error MSB3552: Resource file "**/*.resx" cannot be found.`

One workaround is to config the paths in Startup.cs like this:
```
services.AddContentTypeIcons(x =>
{
    //...
    x.CachePath = System.IO.Path.Combine("[appDataPath]", "thumb_cache");
    x.CustomFontPath = System.IO.Path.Combine("[appDataPath]", "font");
});
```
